### PR TITLE
enhance keycloak configuration 

### DIFF
--- a/.nginx/compose/nginx-dev.conf
+++ b/.nginx/compose/nginx-dev.conf
@@ -7,6 +7,8 @@ server {
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header   X-Forwarded-Host $server_name;
+    proxy_set_header   X-Forwarded-Proto $scheme;
+    proxy_set_header   X-Forwarded-Port $server_port;
 
     location / {
         # proxy the request to your build which is running outside of docker

--- a/.nginx/compose/nginx.conf
+++ b/.nginx/compose/nginx.conf
@@ -7,6 +7,8 @@ server {
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header   X-Forwarded-Host $server_name;
+    proxy_set_header   X-Forwarded-Proto $scheme;
+    proxy_set_header   X-Forwarded-Port $server_port;
 
     location / {
         proxy_pass      http://landing-page/;

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -50,7 +50,7 @@ services:
       KC_DB_USERNAME: postgres
       KC_DB_PASSWORD: postgres
 
-      KC_HOSTNAME: localhost
+      KC_HOSTNAME_STRICT: false
       KC_PROXY: edge
       KC_HTTP_RELATIVE_PATH: /keycloak
       KC_HTTP_PORT: 80

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -50,7 +50,7 @@ services:
       KC_DB_USERNAME: postgres
       KC_DB_PASSWORD: postgres
 
-      KC_HOSTNAME: localhost
+      KC_HOSTNAME_STRICT: false
       KC_PROXY: edge
       KC_HTTP_RELATIVE_PATH: /keycloak
       KC_HTTP_PORT: 80


### PR DESCRIPTION
Part of Gamify-IT/issues#274

Changed the keycloak configuraton in the `docker-compose*.yaml` files, so the hostname doesn't matter  and added some keycloak relevant proxy headers.
So this repo matches the configuration in the other repos.