### PR TITLE
write course id into route

### DIFF
--- a/src/views/StartView.vue
+++ b/src/views/StartView.vue
@@ -36,7 +36,7 @@ function courseToButtonElement(course: Course): ButtonElement {
 }
 
 function selectCourse(id: number) {
-  const url = config.overworldBaseUrl + '#' + id;
+  const url = config.overworldBaseUrl + id;
   openSite(url);
 }
 


### PR DESCRIPTION
This PR inserts the ID directly into the route (`/overworld/$ID`) istead of using an url fragment (`/overworld/#$ID`)

Part of Gamify-IT/issues#251

**please only merge if the change is also done in the overworld -> https://github.com/Gamify-IT/overworld/pull/117**