### PR TITLE
fix route redirection depending on login status

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,11 @@
 export default {
   auth: {
     /**
+     * The routes that can only be viewed by authenticated users.
+     * The list contains names of routes from router/index.ts.
+     */
+    protectedRoutes: ['Start', 'App'],
+    /**
      * The token is renewed renewSecondsBeforeTimeout before the access token expires.
      */
     renewSecondsBeforeTimeout: 10,

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import Toast from 'vue-toastification';
 import 'vue-toastification/dist/index.css';
 import { auth } from '@/ts/auth';
 import { keycloak } from '@/ts/keycloak-rest-client';
+import config from '@/config';
 
 router.beforeEach(async (to, _from, next) => {
   await auth.tryRenewAccessToken();
@@ -18,13 +19,13 @@ router.beforeEach(async (to, _from, next) => {
 
   if (isLoggedIn && to.name == 'Login') {
     console.log('STATUS: user is logged in, redirect to app');
-    next({ name: 'App' });
-  } else if (!isLoggedIn && to.name == 'App') {
+    next({ name: 'Start' });
+  } else if (!isLoggedIn && config.auth.protectedRoutes.includes(to.name as string)) {
     console.log('STATUS: user is not logged in, redirect to login');
     next({ name: 'Login' });
   } else if (to.name == 'Not-Found') {
     console.log('STATUS: not found');
-    next({ name: 'App' });
+    next({ name: 'Start' });
   } else {
     console.log('STATUS: do nothing', to.name);
     next();


### PR DESCRIPTION
Closes Gamify-IT/issues#337

## How to test this

1. start the project with `docker-compose up`
3. open http://localhost/app
4. verify that you are redirected to http://localhost ("Authentication required")
5. open http://localhost/start
6. verify that you are redirected to http://localhost ("Authentication required")
    At this point, you have validated the first point in the DoD of Gamify-IT/issues#337
7. log in (e.g. as "max")
8. after the login, verify that you are redirected to http://localhost/start (NOT `/app`) 
9. try to open http://localhost/
10. you should be redirected to http://localhost/start (NOT `/app`)
       At this point, you have validated the second point in the DoD of Gamify-IT/issues#337