### PR TITLE
Improve visual feedback and error handling

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,22 +1,20 @@
 <script lang="ts" setup>
-import { keycloak } from '@/ts/keycloak-rest-client';
+import LoadingSpinner from '@/components/LoadingSpinner.vue';
+import { keycloakConfiguration } from '@/ts/keycloak-configuration';
 
-const isLoading = keycloak.isLoading;
-
-keycloak.configure();
+const isLoading = keycloakConfiguration.isLoading;
 </script>
 
 <template>
   <div v-if="isLoading" class="loading-screen">
     <div class="loading-center-box">
-      <h1 class="loading-header">Loading</h1>
-      <div class="loading-spinner"></div>
+      <LoadingSpinner />
     </div>
   </div>
   <router-view v-else />
 </template>
 
-<style lang="css">
+<style lang="css" scoped>
 .loading-screen {
   width: 100vw;
   height: 100vh;
@@ -27,40 +25,5 @@ keycloak.configure();
   margin: auto;
   display: flex;
   flex-direction: column;
-}
-
-.loading-header {
-  text-align: center;
-  margin: 0 auto 20px auto;
-  color: #444;
-}
-
-.loading-spinner {
-  display: inline-block;
-  width: 80px;
-  height: 80px;
-  margin: 0 auto;
-}
-
-.loading-spinner:after {
-  content: ' ';
-  display: block;
-  width: 64px;
-  height: 64px;
-  margin: 8px;
-  border-radius: 50%;
-  border: 6px solid #aaa;
-  border-left-color: transparent;
-  border-right-color: transparent;
-  animation: loading-spinner 1.2s linear infinite;
-}
-
-@keyframes loading-spinner {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,3 +1,66 @@
+<script lang="ts" setup>
+import { keycloak } from '@/ts/keycloak-rest-client';
+
+const isLoading = keycloak.isLoading;
+
+keycloak.configure();
+</script>
+
 <template>
-  <router-view />
+  <div v-if="isLoading" class="loading-screen">
+    <div class="loading-center-box">
+      <h1 class="loading-header">Loading</h1>
+      <div class="loading-spinner"></div>
+    </div>
+  </div>
+  <router-view v-else />
 </template>
+
+<style lang="css">
+.loading-screen {
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+}
+
+.loading-center-box {
+  margin: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.loading-header {
+  text-align: center;
+  margin: 0 auto 20px auto;
+  color: #444;
+}
+
+.loading-spinner {
+  display: inline-block;
+  width: 80px;
+  height: 80px;
+  margin: 0 auto;
+}
+
+.loading-spinner:after {
+  content: ' ';
+  display: block;
+  width: 64px;
+  height: 64px;
+  margin: 8px;
+  border-radius: 50%;
+  border: 6px solid #aaa;
+  border-left-color: transparent;
+  border-right-color: transparent;
+  animation: loading-spinner 1.2s linear infinite;
+}
+
+@keyframes loading-spinner {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/src/components/ButtonBox.vue
+++ b/src/components/ButtonBox.vue
@@ -1,15 +1,19 @@
-<script setup lang="ts">
-import { ButtonElement } from '@/types/index';
+<script lang="ts" setup>
 defineProps<{
-  buttonElement: ButtonElement;
+  color: string;
+  description: string;
 }>();
 </script>
 
 <template>
-  <div id="button-box" :class="buttonElement.color">
-    <div class="text-center position-relative top-50 start-50 translate-middle" :title="buttonElement.description">
-      <h4>{{ buttonElement.title }}</h4>
-      <div>{{ buttonElement.subtitle }}</div>
+  <div id="button-box" :class="color">
+    <div :title="description" class="text-center position-relative top-50 start-50 translate-middle">
+      <h4>
+        <slot name="title" />
+      </h4>
+      <div>
+        <slot name="subtitle" />
+      </div>
     </div>
   </div>
 </template>

--- a/src/components/LoadingSpinner.vue
+++ b/src/components/LoadingSpinner.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="loading-spinner"></div>
+</template>
+
+<style lang="css" scoped>
+.loading-spinner {
+  display: inline-block;
+  width: 80px;
+  height: 80px;
+  margin: 0 auto;
+}
+
+.loading-spinner:after {
+  content: ' ';
+  display: block;
+  width: 64px;
+  height: 64px;
+  margin: 8px;
+  border-radius: 50%;
+  border: 6px solid #aaa;
+  border-left-color: transparent;
+  border-right-color: transparent;
+  animation: loading-spinner 1.2s linear infinite;
+}
+
+@keyframes loading-spinner {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,8 +11,10 @@ import Toast from 'vue-toastification';
 import 'vue-toastification/dist/index.css';
 import { auth } from '@/ts/auth';
 import config from '@/config';
+import { keycloakConfiguration } from '@/ts/keycloak-configuration';
 
 router.beforeEach(async (to, _from, next) => {
+  await keycloakConfiguration.configurationComplete;
   await auth.tryRenewAccessToken();
   const isLoggedIn = await auth.tryUpdateUserInfo();
 
@@ -33,6 +35,8 @@ router.beforeEach(async (to, _from, next) => {
 
 async function main() {
   await store.commit('init');
+  keycloakConfiguration.startConfiguration();
+
   const app = createApp(App);
 
   app.use(BootstrapVue3);

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,6 @@ import 'bootstrap-vue-3/dist/bootstrap-vue-3.css';
 import Toast from 'vue-toastification';
 import 'vue-toastification/dist/index.css';
 import { auth } from '@/ts/auth';
-import { keycloak } from '@/ts/keycloak-rest-client';
 import config from '@/config';
 
 router.beforeEach(async (to, _from, next) => {
@@ -34,7 +33,6 @@ router.beforeEach(async (to, _from, next) => {
 
 async function main() {
   await store.commit('init');
-  await keycloak.configure();
   const app = createApp(App);
 
   app.use(BootstrapVue3);

--- a/src/ts/iframeLoader.ts
+++ b/src/ts/iframeLoader.ts
@@ -1,3 +1,5 @@
+import router from '@/router';
+
 export function loadIframe(url: string) {
   const iframe = document.createElement('iframe');
   iframe.src = url;
@@ -12,7 +14,7 @@ export function loadIframe(url: string) {
       const iframe = document.querySelector('#iframe-wrapper>iframe');
       if (iframe != null) {
         iframe.remove();
-        window.open('/start', '_self');
+        router.push({ name: 'Start' });
       }
     }
   });

--- a/src/ts/keycloak-configuration.ts
+++ b/src/ts/keycloak-configuration.ts
@@ -1,0 +1,97 @@
+import { OpenIDConfiguration } from '@/types';
+import { ref } from 'vue';
+import axios from 'axios';
+import config from '@/config';
+
+/**
+ * The Keycloak configuration.
+ * Before using the configuration, the configuration must be loaded.
+ */
+class KeycloakConfiguration {
+  /**
+   * The OpenID configuration for our login.
+   * DO NOT ACCESS DIRECTLY! Use the {@link openIDConfig} getter.
+   * @private
+   */
+  private _openIdConfig: OpenIDConfiguration | null = null;
+
+  /**
+   * Check if the configuration for the login is loaded.
+   * @private
+   */
+  private _isLoading = ref<boolean>(true);
+
+  get isLoading() {
+    return this._isLoading;
+  }
+
+  /**
+   * Check if the configuration for the login is loaded.
+   * @private
+   */
+  private _isConfigured = ref<boolean>(false);
+
+  /**
+   * Check if the client is loaded.
+   */
+  get isConfigured() {
+    return this._isConfigured;
+  }
+
+  /**
+   * Promise that resolves when the configuration is complete.
+   */
+  get configurationComplete() {
+    return this._configurationCompletePromise;
+  }
+
+  /**
+   * Getter for safe access to the OpenID configuration.
+   * @throws Error if the configuration is not yet loaded.
+   */
+  get openIDConfig(): OpenIDConfiguration {
+    if (!this._openIdConfig) {
+      throw new Error('OpenID configuration not configured');
+    }
+    return this._openIdConfig;
+  }
+
+  /**
+   * Fetch the OpenID configuration.
+   * @throws Error if the configuration could not be fetched.
+   */
+  startConfiguration() {
+    this._loadOpenIDConfiguration();
+  }
+
+  /**
+   * Fetch the OpenID configuration.
+   * @private
+   */
+  async _loadOpenIDConfiguration(): Promise<void> {
+    this._isLoading.value = true;
+    try {
+      this._openIdConfig = (await axios.get(config.auth.keycloak.configurationURL)).data;
+      this._isConfigured.value = true;
+    } catch (e) {
+      console.error('Could not fetch OpenID configuration', e);
+    }
+    this._isLoading.value = false;
+    this._configurationCompletePromiseResolve();
+  }
+
+  private _configurationCompletePromiseResolve: () => void = () => null;
+
+  /**
+   * Promise for waiting until the configuration is loaded.
+   * @private
+   */
+  private _configurationCompletePromise = new Promise<void>((resolve) => {
+    this._configurationCompletePromiseResolve = resolve as () => void;
+  });
+}
+
+/**
+ * The Keycloak configuration singleton.
+ */
+export const keycloakConfiguration = new KeycloakConfiguration();

--- a/src/ts/keycloak-configuration.ts
+++ b/src/ts/keycloak-configuration.ts
@@ -68,7 +68,7 @@ class KeycloakConfiguration {
    * Fetch the OpenID configuration.
    * @private
    */
-  async _loadOpenIDConfiguration(): Promise<void> {
+  private async _loadOpenIDConfiguration(): Promise<void> {
     this._isLoading.value = true;
     try {
       this._openIdConfig = (await axios.get(config.auth.keycloak.configurationURL)).data;

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -4,8 +4,9 @@ import store from '@/store';
 import { QueryParams } from '@/ts/query';
 import { auth } from '@/ts/auth';
 import router from '@/router';
+import { keycloakConfiguration } from '@/ts/keycloak-configuration';
 
-const keycloakIsConfigured = keycloak.isConfigured;
+const keycloakIsConfigured = keycloakConfiguration.isConfigured;
 
 async function redirectIfUserIsSignedIn() {
   await auth.tryGetAccessTokenWithCode(QueryParams.get('code'));

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -1,9 +1,11 @@
-<script setup lang="ts">
+<script lang="ts" setup>
 import { keycloak } from '@/ts/keycloak-rest-client';
 import store from '@/store';
 import { QueryParams } from '@/ts/query';
 import { auth } from '@/ts/auth';
 import router from '@/router';
+
+const keycloakIsConfigured = keycloak.isConfigured;
 
 async function redirectIfUserIsSignedIn() {
   await auth.tryGetAccessTokenWithCode(QueryParams.get('code'));
@@ -21,22 +23,28 @@ redirectIfUserIsSignedIn();
   <b-container class="mt-5">
     <b-row class="d-flex justify-content-center">
       <b-col md="6">
-        <b-card class="px-5 py-5" id="form">
+        <b-card id="form" class="px-5 py-5">
           <div v-if="store.state.accessToken">
             <h1>Login successful</h1>
             <div>Welcome user "{{ store.state.preferredUsername }}"</div>
           </div>
-          <div v-else>
+          <div v-else-if="keycloakIsConfigured">
             <h1>Authentication required</h1>
             <div>You need to log in to view this page.</div>
-            <a :href="keycloak.loginUri"><b-button type="submit" variant="dark" class="w-100">Go to login</b-button></a>
+            <a :href="keycloak.loginUri">
+              <b-button class="w-100" type="submit" variant="dark">Go to login</b-button>
+            </a>
+          </div>
+          <div v-else>
+            <h1>Authentication failed</h1>
+            <div>Please check your internet connection or try again later.</div>
           </div>
         </b-card>
       </b-col>
     </b-row>
   </b-container>
   <div class="text-center">
-    <a href="/third-party-license-notice/" class="text-body">Third Party Licenses</a>
+    <a class="text-body" href="/third-party-license-notice/">Third Party Licenses</a>
   </div>
 </template>
 
@@ -49,10 +57,12 @@ redirectIfUserIsSignedIn();
   padding: 5px 10px;
   font-size: 15px;
 }
+
 .forms-inputs input {
   height: 50px;
   border: 2px solid #eee;
 }
+
 .forms-inputs input:focus {
   box-shadow: none;
   outline: none;

--- a/src/views/StartView.vue
+++ b/src/views/StartView.vue
@@ -2,15 +2,17 @@
 import ButtonBox from '@/components/ButtonBox.vue';
 import LogoutButton from '@/components/LogoutButton.vue';
 import { ButtonElement, Color, Course } from '@/types';
-import { getActiveCourses } from '@/ts/start';
 import config from '@/config';
 import { ref } from 'vue';
 import store from '@/store';
 import router from '@/router';
 import { auth } from '@/ts/auth';
+import LoadingSpinner from '@/components/LoadingSpinner.vue';
+import { getActiveCourses } from '@/ts/start';
 
 const courseColor = Color.PRIMARY;
 const setupColor = Color.WARNING;
+const placeholderColor = Color.LIGHT;
 
 auth.testLogin();
 
@@ -33,15 +35,6 @@ const keycloakAdminInterface: ButtonElement = {
   color: setupColor,
 };
 
-function courseToButtonElement(course: Course): ButtonElement {
-  return {
-    title: course.courseName,
-    subtitle: course.semester,
-    description: course.description,
-    color: courseColor,
-  };
-}
-
 function selectCourse(id: number) {
   const url = config.overworldBaseUrl + id;
   openSite(url);
@@ -62,12 +55,26 @@ function openSite(url: string) {
     <div>
       <h2>Play</h2>
       <div class="m-2">
-        <div class="d-flex flex-wrap justify-content-start">
+        <div v-if="courses" class="d-flex flex-wrap justify-content-start">
           <div v-for="course in courses" v-bind:key="course.id">
-            <ButtonBox :button-element="courseToButtonElement(course)" @click="selectCourse(course.id)" />
+            <ButtonBox :color="courseColor" :description="course.description" @click="selectCourse(course.id)">
+              <template #title>{{ course.courseName }}</template>
+              <template #subtitle>{{ course.semester }}</template>
+            </ButtonBox>
           </div>
-          <div v-if="!courses" class="display-6">Loading...</div>
-          <div v-else-if="courses.length === 0" class="display-6">Nothing to show :(</div>
+          <div v-if="courses && courses.length === 0" class="display-6">
+            <h4>No courses available</h4>
+          </div>
+        </div>
+
+        <div v-else class="d-flex flex-wrap justify-content-start">
+          <div v-for="i in 3" v-bind:key="i">
+            <ButtonBox :color="placeholderColor" description="Loading">
+              <template #subtitle>
+                <LoadingSpinner />
+              </template>
+            </ButtonBox>
+          </div>
         </div>
       </div>
     </div>
@@ -76,9 +83,19 @@ function openSite(url: string) {
       <h2>Setup</h2>
       <div class="m-2">
         <div class="d-flex flex-wrap justify-content-start">
-          <ButtonBox :button-element="lecturerInterface" @click="openSite(config.lecturerInterfaceBaseUrl)" />
+          <ButtonBox
+            :color="lecturerInterface.color"
+            :description="lecturerInterface.description"
+            @click="openSite(config.lecturerInterfaceBaseUrl)"
+          >
+            <template #title>{{ lecturerInterface.title }}</template>
+            <template #subtitle>{{ lecturerInterface.subtitle }}</template>
+          </ButtonBox>
           <a :href="config.keycloakAdminUrl" class="link-card-wrapper" target="_blank">
-            <ButtonBox :button-element="keycloakAdminInterface" />
+            <ButtonBox :color="keycloakAdminInterface.color" :description="keycloakAdminInterface.description">
+              <template #title>{{ keycloakAdminInterface.title }}</template>
+              <template #subtitle>{{ keycloakAdminInterface.subtitle }}</template>
+            </ButtonBox>
           </a>
         </div>
       </div>

--- a/src/views/StartView.vue
+++ b/src/views/StartView.vue
@@ -11,15 +11,23 @@ import LoadingSpinner from '@/components/LoadingSpinner.vue';
 import { getActiveCourses } from '@/ts/start';
 
 const courseColor = Color.PRIMARY;
-const setupColor = Color.WARNING;
+const setupColor = Color.INFO;
 const placeholderColor = Color.LIGHT;
+const warningColor = Color.WARNING;
+
+let courseFetchFailed = ref(false);
 
 auth.testLogin();
 
 const courses = ref<Course[]>();
-getActiveCourses().then((fetchedCourses) => {
-  courses.value = fetchedCourses;
-});
+getActiveCourses()
+  .then((fetchedCourses) => {
+    courses.value = fetchedCourses;
+  })
+  .catch((error) => {
+    console.error('Error while fetching courses: ', error);
+    courseFetchFailed.value = true;
+  });
 
 const lecturerInterface: ButtonElement = {
   title: 'Lecturer Interface',
@@ -66,7 +74,14 @@ function openSite(url: string) {
             <h4>No courses available</h4>
           </div>
         </div>
-
+        <div v-else-if="courseFetchFailed" class="d-flex flex-wrap justify-content-start">
+          <div>
+            <ButtonBox :color="warningColor" description="Loading">
+              <template #title>Unable to contact server</template>
+              <template #subtitle>Please try again later</template>
+            </ButtonBox>
+          </div>
+        </div>
         <div v-else class="d-flex flex-wrap justify-content-start">
           <div v-for="i in 3" v-bind:key="i">
             <ButtonBox :color="placeholderColor" description="Loading">

--- a/tests/unit/auth.spec.ts
+++ b/tests/unit/auth.spec.ts
@@ -1,8 +1,6 @@
-import { mount, VueWrapper, flushPromises } from '@vue/test-utils';
 import mockAxios from '@/__mocks__/axios';
 import config from '@/config';
-import { keycloak } from '@/ts/keycloak-rest-client';
-import { auth } from '@/ts/auth';
+import { keycloakConfiguration } from '@/ts/keycloak-configuration';
 
 const openIDConfig = {
   issuer: 'http://localhost/keycloak/realms/Gamify-IT',
@@ -16,7 +14,7 @@ const openIDConfig = {
 describe('auth.ts', () => {
   beforeEach(async () => {
     mockAxios.get.mockResolvedValueOnce(openIDConfig);
-    await keycloak.configure();
+    await keycloakConfiguration.startConfiguration();
     expect(mockAxios.get).toHaveBeenCalledWith(config.auth.keycloak.configurationURL);
   });
 


### PR DESCRIPTION
Closes Gamify-IT/issues#293

## Improvements
- [x] add loading spinner while authentication is loading
- [x] add error message if Keycloak cannot be contacted
- [x] add loading spinner while courses are loading
- [x] improve error message if courses cannot be loaded

## How to test this
- `docker-compose -f docker-compose-dev.yaml up`
- `npm run serve`
- go to http://localhost (should briefly show a loading spinner)
- `docker stop keycloak`
- reload -> should show the **loading spinner**; after a few seconds (15-20?) it should show an **error message**
- `docker start keycloak`
- `docker restart reverse-proxy`
- reload -> should show authentication screen
- login
- for a brief time there should be **three placeholder cards** with loading spinners before the courses are displayed
- `docker stop overworld-backend`
- reload -> there should be **three placeholder cards** for a few seconds, then a **card with an error message**