### PR TITLE
Focus iframe when loaded

### DIFF
--- a/src/ts/iframeLoader.ts
+++ b/src/ts/iframeLoader.ts
@@ -1,6 +1,6 @@
 import router from '@/router';
 
-export function loadIframe(url: string) {
+export function loadIframe(url: string, focus = true) {
   const iframe = document.createElement('iframe');
   iframe.src = url;
   iframe.style.position = 'fixed';
@@ -24,5 +24,8 @@ export function loadIframe(url: string) {
     iframeWrapper.appendChild(iframe);
   } else {
     throw new Error('iframe wrapper not found!');
+  }
+  if (focus) {
+    iframe.contentWindow?.focus();
   }
 }

--- a/src/ts/iframeLoader.ts
+++ b/src/ts/iframeLoader.ts
@@ -16,6 +16,11 @@ export function loadIframe(url: string, focus = true) {
         iframe.remove();
         router.push({ name: 'Start' });
       }
+    } else if (event.data === 'FOCUS ME') {
+      const iframe: HTMLIFrameElement | null = document.querySelector('#iframe-wrapper>iframe');
+      if (iframe != null) {
+        iframe.contentWindow?.focus();
+      }
     }
   });
 


### PR DESCRIPTION
This should automatically focus the game when joining a course.
Test it with starting the docker compose file `docker compose up`. Login with an account of your choice and join a course. After you clicked on the course button, do not click anything again, to not focus the window manually. When the game loaded, try to walk. If this works without focusing manually then implemented change work!