### PR TITLE
Removed '/play' from the URL after selecting a Course

### DIFF
--- a/src/views/StartView.vue
+++ b/src/views/StartView.vue
@@ -56,7 +56,7 @@ const fileserver: ButtonElement = {
 };
 
 function selectCourse(id: number) {
-  const url = config.overworldBaseUrl + id + '/play';
+  const url = config.overworldBaseUrl + id;
   openSite(url);
 }
 


### PR DESCRIPTION
Removed '/play' from the URL that is being parsed after selecting a Course.
Now the landing-page on the main branch should be working